### PR TITLE
fix: add homepage link to navbar title

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -43,7 +44,9 @@ export function MainContent({ user, project }: MainContentProps) {
               <div className="h-full flex flex-col bg-white">
                 {/* Chat Header */}
                 <div className="h-14 flex items-center px-6 border-b border-neutral-200/60">
-                  <h1 className="text-lg font-semibold text-neutral-900 tracking-tight">React Component Generator</h1>
+                  <Link href="/">
+                    <h1 className="text-lg font-semibold text-neutral-900 tracking-tight hover:opacity-75 transition-opacity">React Component Generator</h1>
+                  </Link>
                 </div>
 
                 {/* Chat Content */}


### PR DESCRIPTION
Wraps the navbar title "React Component Generator" with a Next.js Link component pointing to the homepage (`/`).

Fixes #1

Generated with [Claude Code](https://claude.ai/code)